### PR TITLE
cached first item size

### DIFF
--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -177,6 +177,8 @@ class _SnappyListViewState extends State<SnappyListView> {
 
   bool initialBuild = true;
 
+  double? firstItemSize;
+
   @override
   void initState() {
     super.initState();
@@ -395,9 +397,13 @@ class _SnappyListViewState extends State<SnappyListView> {
       final itemSize = internalSizes.elementAt(internalItemIndex).size;
       assert(itemSize <= maxScrollDirectionSize,
           "The size of each item is limited to the maximum size of the scroll area.");
+      if (index == 0 && firstItemSize == null) {
+        firstItemSize = itemSize;
+      }
       return itemSize;
     } else {
-      return 0;
+      // Return cached size of the first item if `index == 0` and size is not present in the `internalSizes`
+      return index == 0 ? firstItemSize ?? 0 : 0;
     }
   }
 


### PR DESCRIPTION
## Problem

We have used snappy list view in hotels list, but while implementing scroll to top functionality I faced an issue like sometimes there is additional top padding after scrolling to first index, which was given by snappy list view widget.

## Cause of problem

- Each widget's size is stored in `internalSizes` to calculate padding for alignment.
- The getSize function checks sizes in `internalSizes`.
- Some sizes are removed from `internalSizes` based on scroll position for memory optimization.
- When scrolling to the top, if the 0 index widget size is missing inside `internalSizes`, it miscalculates, adding extra top padding from `calculatePadding`.

```dart
/// Retrieves the size of an item by index, while checking for validity of size
  double getSize(int index) {
    final internalItemIndex =
        internalSizes.indexWhere((element) => element.index == index);
    //initial element alignment correction
    if (internalItemIndex != -1) {
      final itemSize = internalSizes.elementAt(internalItemIndex).size;
      assert(itemSize <= maxScrollDirectionSize,
          "The size of each item is limited to the maximum size of the scroll area.");
      return itemSize;
    } else {
      return 0;
    }
  }
  ```
  
  ```dart
    /// Returns the page padding for the first and last page of the list to simulate
  /// a correct (middle) start/end of the pages
  EdgeInsets getPagePadding() {
    final firstIndex = widget.reverse ? widget.itemCount - 1 : 0;
    final lastIndex = widget.reverse ? 0 : widget.itemCount - 1;
    final firstSnapItem = assignSnapAlignmentItem(firstIndex);
    final lastSnapItem = assignSnapAlignmentItem(lastIndex);
    final firstAlign = widget.snapAlignment.apply(firstSnapItem);
    final lastAlign = widget.snapAlignment.apply(lastSnapItem);
    final firstItemAlign = widget.snapOnItemAlignment.apply(firstSnapItem);
    final lastItemAlign = widget.snapOnItemAlignment.apply(lastSnapItem);
    final firstPadding = maxScrollDirectionSize * firstAlign -
        firstItemAlign * getSize(firstIndex);
    final lastPadding = maxScrollDirectionSize * (1 - lastAlign) -
        (1 - lastItemAlign) * getSize(lastIndex);
    assert(
        firstPadding >= 0 && lastPadding >= 0,
        "Snap- and SnapOnItemAlignment caused border items to overflow. "
        "Please make sure that snap never pushed items out of the viewport.");
    switch (widget.scrollDirection) {
      case Axis.horizontal:
        return EdgeInsets.only(left: firstPadding, right: lastPadding);
      case Axis.vertical:
        return EdgeInsets.only(top: firstPadding, bottom: lastPadding);
    }
  }
  ```
  Inside sync value we are removing sizes for memory optimisation.
  
  ```dart
          final listItems = widget.itemPositionsListener.itemPositions.value;
        internalSizes.removeWhere((element) {
          final keepList = listItems.map((e) => e.index).toList() +
              [listItems.first.index - 1, listItems.first.index + 1];
          return keepList.contains(element.index) == false;
        }); //clears sizes (with buffer for border) to prevent high ram usage
  ```

## Proposed solution

There could be couple of solution either we cache first item size (which I did as of now) or we can avoid removing sizes from `internalSizes`.

- We can store the first item’s size so that, if it’s missing from `internalSizes` due to memory optimization, we can use the stored size for the 0 index widget.

## Screen recording

- I tried scrolling 100+ hotels and its working fine.
- Note: Ignore more icon I have used for testing.

[snappy_scrollview_bug_fix.webm](https://github.com/user-attachments/assets/d293fc9e-cf8c-4748-ab97-90f30ea3a648)
